### PR TITLE
Drop "push" event requirement to allow manual deploys

### DIFF
--- a/.github/workflows/deploy-to-skynet.yml
+++ b/.github/workflows/deploy-to-skynet.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           upload-dir: build
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          registry-seed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.REGISTRY_SEED || '' }}
+          registry-seed: ${{ github.ref == 'refs/heads/main' && secrets.REGISTRY_SEED || '' }}


### PR DESCRIPTION
When using manual workflow on main branch, event name is set to "workflow_dispatch" and prevents including registry seed during deploy action. Checking for event name seems redundant in our case (probably in most cases actually).